### PR TITLE
Use relative urls for fonts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,8 +18,8 @@
 
     <!-- Plugin CSS -->
     <link rel="stylesheet" href="{{ "/css/animate.min.css" | absolute_url }}" type="text/css">
-    <link rel="stylesheet" href="/2016/group5/vendor/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="/2016/group5/vendor/simple-line-icons/css/simple-line-icons.css">
+    <link rel="stylesheet" href="{{ "/vendor/font-awesome/css/font-awesome.min.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/vendor/simple-line-icons/css/simple-line-icons.css" | relative_url }}">
     <link rel="stylesheet" href="{{ "/vendor/device-mockups/device-mockups.min.css" | absolute_url }}">
 
     <!-- Custom CSS


### PR DESCRIPTION
Removes hard-coding of baseurl